### PR TITLE
Remove SITE_PREFIX

### DIFF
--- a/csv_schema/models.py
+++ b/csv_schema/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import json
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth.signals import user_logged_out
 from django.db import models
@@ -14,11 +13,6 @@ from django.utils.text import slugify
 from django_auto_one_to_one import AutoOneToOneModel
 
 from ncdr.models import BaseModel, BaseQuerySet
-
-if getattr(settings, "SITE_PREFIX", ""):
-    SITE_PREFIX = "/{}".format(settings.SITE_PREFIX.strip("/"))
-else:
-    SITE_PREFIX = ""
 
 DATE_FORMAT = "%b %y"
 
@@ -36,15 +30,11 @@ class UserProfile(AutoOneToOneModel(User)):
 
     @classmethod
     def get_url_preview_mode_on(cls):
-        return SITE_PREFIX + reverse(
-            "preview_mode", kwargs=dict(preview_mode=1)
-        )
+        return reverse("preview_mode", kwargs=dict(preview_mode=1))
 
     @classmethod
     def get_url_preview_mode_off(cls):
-        return SITE_PREFIX + reverse(
-            "preview_mode", kwargs=dict(preview_mode=0)
-        )
+        return reverse("preview_mode", kwargs=dict(preview_mode=0))
 
 
 def turn_preview_mode_off(sender, user, request, **kwargs):
@@ -85,15 +75,11 @@ class Database(BaseModel):
         return self.name
 
     def get_absolute_url(self):
-        return SITE_PREFIX + reverse(
-            "database_detail", kwargs=dict(db_name=self.name)
-        )
+        return reverse("database_detail", kwargs=dict(db_name=self.name))
 
     @classmethod
     def get_list_url(self):
-        return SITE_PREFIX + reverse(
-            "database_list"
-        )
+        return reverse("database_list")
 
     def get_display_name(self):
         return self.display_name
@@ -148,10 +134,7 @@ class Table(BaseModel):
     objects = TableQueryset.as_manager()
 
     def get_absolute_url(self):
-        return SITE_PREFIX + reverse("table_detail", kwargs=dict(
-            table_name=self.name,
-            db_name=self.database.name
-        ))
+        return reverse("table_detail", kwargs=dict(table_name=self.name, db_name=self.database.name))
 
     def get_display_name(self):
         return "{} / {}".format(self.database.name, self.name)
@@ -187,9 +170,7 @@ class Grouping(BaseModel, models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return SITE_PREFIX + reverse("grouping_detail", kwargs=dict(
-            slug=self.slug,
-        ))
+        return reverse("grouping_detail", kwargs=dict(slug=self.slug))
 
     def save(self, *args, **kwargs):
         if self.name and not self.slug:
@@ -225,9 +206,7 @@ class DataElement(BaseModel, models.Model):
         return super().save(*args, **kwargs)
 
     def get_absolute_url(self):
-        return SITE_PREFIX + reverse(
-            "data_element_detail", kwargs=dict(slug=self.slug)
-        )
+        return reverse("data_element_detail", kwargs=dict(slug=self.slug))
 
     def get_description(self):
         if self.description:
@@ -339,28 +318,22 @@ class Column(BaseModel, models.Model):
             return stripped.lstrip("www.").split("/")[0]
 
     def get_absolute_url(self):
-        return SITE_PREFIX + reverse("column_detail", kwargs=dict(
-            slug=self.slug,
-        ))
+        return reverse("column_detail", kwargs=dict(slug=self.slug))
 
     @classmethod
     def get_unpublished_list_url(cls):
-        return SITE_PREFIX + reverse("unpublished_list", kwargs=dict(
-            model_name=cls.get_model_api_name()
-        ))
+        return reverse("unpublished_list", kwargs=dict(model_name=cls.get_model_api_name()))
 
     @classmethod
     def get_publish_all_url(cls):
-        return SITE_PREFIX + reverse("publish_all")
+        return reverse("publish_all")
 
     @classmethod
     def get_edit_list_js_template(cls):
         return "forms/column_form_js.html"
 
     def get_publish_url(self):
-        return SITE_PREFIX + reverse("columns-detail", kwargs=dict(
-            pk=self.id
-        ))
+        return reverse("columns-detail", kwargs=dict(pk=self.id))
 
     @cached_property
     def useage_count(self):

--- a/csv_schema/templates/about.html
+++ b/csv_schema/templates/about.html
@@ -7,14 +7,14 @@
         <article>
           <div class="row">
             <div class="col-md-12">
-              <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a> About
+              <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a> About
             </div>
           </div>
 
           <h1>About</h1>
           <div class="row">
             <div class="col-md-12">
-              <img class="header-img" src="{{ settings.SITE_PREFIX }}{% static "/img/stetho-computer.jpg" %}" />
+              <img class="header-img" src="{% static "/img/stetho-computer.jpg" %}" />
             </div>
           </div>
           <p class="content-offset-30">

--- a/csv_schema/templates/base_templates/base.html
+++ b/csv_schema/templates/base_templates/base.html
@@ -33,12 +33,12 @@
     <!-- Latest compiled and minified JavaScript -->
     {% block staticfiles %}
       {% block js %}
-        <script src="{{ settings.SITE_PREFIX }}{% static "js/mark.js/dist/mark.js" %}"></script>
+        <script src="{% static "js/mark.js/dist/mark.js" %}"></script>
       {% endblock js %}
       <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
       {% compress css %}
-      	<link rel="stylesheet" href="{{ settings.SITE_PREFIX }}{% static "css/nhsengland.css" %}">
-      	<link rel="stylesheet" href="{{ settings.SITE_PREFIX }}{% static "css/styles.css" %}">
+      	<link rel="stylesheet" href="{% static "css/nhsengland.css" %}">
+      	<link rel="stylesheet" href="{% static "css/styles.css" %}">
       {% endcompress %}
     {% endblock staticfiles %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.js"></script>
@@ -51,10 +51,10 @@
           <div class="col-md-12 text-center">
           {% if request.user.userprofile.preview_mode %}
               You are currently viewing a preview version of the site
-              <a class="btn pull-right relative" href="{{ settings.SITE_PREFIX }}{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
+              <a class="btn pull-right relative" href="{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
               <a class="btn pull-right relative" href="{{ models.csv_schema.userprofile.get_url_preview_mode_off }}?next={{ request.get_full_path }}">View Normal Site</a>
           {% else %}
-              <a class="btn pull-right relative" href="{{ settings.SITE_PREFIX }}{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
+              <a class="btn pull-right relative" href="{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
               <a class="btn pull-right relative" href="{{ models.csv_schema.userprofile.get_url_preview_mode_on }}?next={{ request.get_full_path }}">Preview Site</a>
           {% endif %}
           {% if view.model %}
@@ -83,14 +83,14 @@
             <div class="top-logo">
               <hgroup class="header-strapline">
                 <a class="logo" href="http://www.england.nhs.uk">
-                  <img src="{{ settings.SITE_PREFIX }}{% static "/img/logos/nhs-england-logo-rev.svg" %}" alt="NHS England Data Catalogue Logo" title="NHS England Data Catalogue Logo" data-intro="Clicking on this logo will always take you back to the homepage (just in case you get lost).">
+                  <img src="{% static "/img/logos/nhs-england-logo-rev.svg" %}" alt="NHS England Data Catalogue Logo" title="NHS England Data Catalogue Logo" data-intro="Clicking on this logo will always take you back to the homepage (just in case you get lost).">
                 </a>
                 <h2 class="subtitle">NCDR Reference Library</h2>
         	    </hgroup>
             </div>
           </div>
           <div class="col-md-5 col-md-push-1 text-right">
-            <form class="ncdr-search" method="get" action="{{ settings.SITE_PREFIX }}/search">
+            <form class="ncdr-search" method="get" action="/search">
               <input type="text" value="{{ request.GET.q }}" name="q" autocomplete="off">
               <button type="submit" class="btn">
                 Search Reference Library
@@ -119,18 +119,18 @@
                   </a>
                 </li>
                 <li>
-                  <a {% if request|url_name == 'data_element_detail' or request|url_name == 'data_element_list' %} class="active" {% endif %} href="{{ settings.SITE_PREFIX }}{{ data_element_list }}">
+                  <a {% if request|url_name == 'data_element_detail' or request|url_name == 'data_element_list' %} class="active" {% endif %} href="{{ data_element_list }}">
                     {{ models.csv_schema.dataelement.get_model_display_name_plural }}
                   </a>
                 </li>
 
                 <li>
-                  <a {% if request|url_name == 'grouping_detail' %}class="active" {% endif %} href="{{ settings.SITE_PREFIX }}{{ grouping_redirect }}">
+                  <a {% if request|url_name == 'grouping_detail' %}class="active" {% endif %} href="{{ grouping_redirect }}">
                     {{ models.csv_schema.grouping.get_model_display_name_plural }}
                   </a>
                 </li>
                 <li>
-                  <a {% ifequal request.path about_page %}class="active" {% endifequal %} href="{{ settings.SITE_PREFIX }}{{ about_page }}">
+                  <a {% ifequal request.path about_page %}class="active" {% endifequal %} href="{{ about_page }}">
                     About
                   </a>
                 </li>
@@ -154,7 +154,7 @@
                   <ul class="nav">
                     {% if request.user.is_authenticated %}
                       <li>
-                        <a href="{{ settings.SITE_PREFIX }}{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
+                        <a href="{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
                     	</li>
                     {% else %}
                       <li>

--- a/csv_schema/templates/column_detail.html
+++ b/csv_schema/templates/column_detail.html
@@ -5,7 +5,7 @@
     <div class="col-md-12">
       <div class="row">
         <div class="col-md-12">
-          <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{{ object.table.database.get_absolute_url }}">{{ object.table.database.get_display_name }}</a><a class="ncdr-breadcrumbs" href="{{ object.table.get_absolute_url }}"> {{ object.table.name }}</a>{{ object.name }}
+          <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{{ object.table.database.get_absolute_url }}">{{ object.table.database.get_display_name }}</a><a class="ncdr-breadcrumbs" href="{{ object.table.get_absolute_url }}"> {{ object.table.name }}</a>{{ object.name }}
         </div>
       </div>
 

--- a/csv_schema/templates/column_list.html
+++ b/csv_schema/templates/column_list.html
@@ -4,7 +4,7 @@
 {% block contents %}
   <div class="card-list container main-content">
     <article>
-      <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'column_redirect' %}">{{ models.csv_schema.column.get_model_display_name_plural }}</a>{{ view.kwargs.letter }}
+      <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{% url 'column_redirect' %}">{{ models.csv_schema.column.get_model_display_name_plural }}</a>{{ view.kwargs.letter }}
       <nav class="content-offset">
         <div class="row">
           <div class="col-md-12">

--- a/csv_schema/templates/data_element_detail.html
+++ b/csv_schema/templates/data_element_detail.html
@@ -6,7 +6,7 @@
     <div class="col-md-12">
       <div class="row">
         <div class="col-md-12">
-          <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'data_element_list' %}">Data Elements</a><a class="ncdr-breadcrumbs" href="{{ object.get_bread_crumb_link }}"> {{ object.get_bread_crumb_name }}</a>{{ object.name }}
+          <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{% url 'data_element_list' %}">Data Elements</a><a class="ncdr-breadcrumbs" href="{{ object.get_bread_crumb_link }}"> {{ object.get_bread_crumb_name }}</a>{{ object.name }}
         </div>
       </div>
 

--- a/csv_schema/templates/data_element_list.html
+++ b/csv_schema/templates/data_element_list.html
@@ -4,7 +4,7 @@
 {% block contents %}
   <div class="card-list container main-content">
     <article>
-      <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a>{{ models.csv_schema.dataelement.get_model_display_name_plural }}
+      <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a>{{ models.csv_schema.dataelement.get_model_display_name_plural }}
       <div class="row">
         <div class="col-md-12">
           <h1 class="title">

--- a/csv_schema/templates/database_detail.html
+++ b/csv_schema/templates/database_detail.html
@@ -22,7 +22,7 @@
     </ul>
   </aside>
   <article class="col-md-8">
-    <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a>{{ object.get_display_name }}
+    <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a>{{ object.get_display_name }}
     <h1 class="title">
       <div class="row">
         <div class="col-sm-12">

--- a/csv_schema/templates/grouping_detail.html
+++ b/csv_schema/templates/grouping_detail.html
@@ -4,7 +4,7 @@
 {% block contents %}
   <div class="main-content container main-content">
     <article >
-      <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'grouping_redirect' %}">Groupings</a>{{ object.name }}
+      <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{% url 'grouping_redirect' %}">Groupings</a>{{ object.name }}
       <h1 class="title">
         <div class="row">
           <div class="col-sm-12">

--- a/csv_schema/templates/table_detail.html
+++ b/csv_schema/templates/table_detail.html
@@ -20,7 +20,7 @@
       </ul>
     </aside>
     <article class="col-md-8">
-      <a class="ncdr-breadcrumbs" href="{{ settings.SITE_PREFIX }}{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{{ object.database.get_absolute_url }}"> {{ object.database.get_display_name }}</a>{{ object.name }}
+      <a class="ncdr-breadcrumbs" href="{% url 'database_list' %}">Home</a><a class="ncdr-breadcrumbs" href="{{ object.database.get_absolute_url }}"> {{ object.database.get_display_name }}</a>{{ object.name }}
       <h1 class="title">
         <div class="row">
           <div class="col-sm-12">

--- a/csv_schema/views.py
+++ b/csv_schema/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -11,11 +10,6 @@ from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, ListView, RedirectView, TemplateView, View
 
 from . import models
-
-if getattr(settings, "SITE_PREFIX", ""):
-    SITE_PREFIX = "/{}".format(settings.SITE_PREFIX.strip("/"))
-else:
-    SITE_PREFIX = ""
 
 
 class NCDRDisplay(object):

--- a/deployment/templates/nginx_site.conf.jinja2
+++ b/deployment/templates/nginx_site.conf.jinja2
@@ -14,7 +14,11 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:4567;
+
+        proxy_redirect http://127.0.0.1:4567/ncdr/ http://$host/ncdr/;
+
         proxy_set_header Host $host;
+        proxy_set_header SCRIPT_NAME /ncdr;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/ncdr/models.py
+++ b/ncdr/models.py
@@ -2,17 +2,10 @@ import functools
 import itertools
 import operator
 
-from django.conf import settings
 from django.db import models
 from django.urls import reverse
 
 MOST_RECENT = "Most Recent"
-
-
-def reverse_with_prefix(name, kwargs):
-    # TODO: remove this knowledge from the project
-    prefix = "/{}".format(settings.SITE_PREFIX.strip("/"))
-    return prefix + reverse(name, kwargs=kwargs)
 
 
 class BaseQuerySet(models.QuerySet):
@@ -87,13 +80,11 @@ class BaseModel(models.Model):
 
     @classmethod
     def get_add_url(cls):
-        kwargs = {"model_name": cls.get_model_api_name()}
-        return reverse_with_prefix("add_many", kwargs)
+        return reverse("add_many", kwargs={"model_name": cls.get_model_api_name()})
 
     @classmethod
     def get_search_url(cls):
-        kwargs = {"model_name": cls.get_model_api_name()}
-        return reverse_with_prefix("search", kwargs)
+        return reverse("search", kwargs={"model_name": cls.get_model_api_name()})
 
     @classmethod
     def get_create_template(cls):
@@ -104,12 +95,10 @@ class BaseModel(models.Model):
         return "search/{}.html".format(cls.get_model_api_name())
 
     def get_edit_url(self):
-        kwargs = {"pk": self.id, "model_name": self.get_model_api_name()}
-        return reverse_with_prefix("edit", kwargs)
+        return reverse("edit", kwargs={"pk": self.id, "model_name": self.get_model_api_name()})
 
     def get_delete_url(self):
-        kwargs = {"pk": self.id, "model_name": self.get_model_api_name()}
-        return reverse_with_prefix("delete", kwargs)
+        return reverse("delete", kwargs={"pk": self.id, "model_name": self.get_model_api_name()})
 
     def get_display_name(self):
         return self.name

--- a/ncdr/settings.py
+++ b/ncdr/settings.py
@@ -25,10 +25,6 @@ SECRET_KEY = 'TOBEOVERRIDDEN'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-# e.g.
-# SITE_PREFIX = "/hello"
-# ie without trailing /
-SITE_PREFIX = ""
 
 # Application definition
 


### PR DESCRIPTION
This removes the `SITE_PREFIX` setting, and it's use for URL generation.

Instead we will use Nginx and the `SCRIPT_NAME` header (part of the WSGI spec) to tell Django it's being run under a URL.  Django will build URLs correctly using this information.

This isn't a perfect solution since `STATIC_URL` must still be configured with knowledge of the URL the app is being run under, but that can be handled in local env settings.