### PR TITLE
Fix Preview Mode

### DIFF
--- a/csv_schema/templates/base_templates/base.html
+++ b/csv_schema/templates/base_templates/base.html
@@ -49,14 +49,15 @@
       <div class="container content-offset-10">
         <div class="row">
           <div class="col-md-12 text-center">
-          {% if request.user.preview_mode %}
-              You are currently viewing a preview version of the site
-              <a class="btn pull-right relative" href="{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
-              <a class="btn pull-right relative" href="{{ models.csv_schema.get_url_preview_mode_off }}?next={{ request.get_full_path }}">View Normal Site</a>
-          {% else %}
-              <a class="btn pull-right relative" href="{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
-              <a class="btn pull-right relative" href="{{ models.csv_schema.get_url_preview_mode_on }}?next={{ request.get_full_path }}">Preview Site</a>
-          {% endif %}
+            {% if request.user.preview_mode %}You are currently viewing a preview version of the site{% endif %}
+            <a class="btn pull-right relative" href="{% url 'logout' %}?next={{ request.get_full_path }}">Log Out</a>
+            <a class="btn pull-right relative" href="{% url 'toggle-preview-mode' %}?next={{ request.get_full_path }}">
+              {% if request.user.preview_mode %}
+              View Normal Site
+              {% else %}
+              Preview Site
+              {% endif %}
+            </a>
           {% if view.model %}
             {% if object %}
               {% if request|url_name == 'edit' %}

--- a/csv_schema/test/test_views.py
+++ b/csv_schema/test/test_views.py
@@ -77,42 +77,35 @@ class AbstractViewTestCase(TestCase):
             self.create_csv_column(**default_kwargs)
 
 
-class PreviewModeSwitchTestCase(AbstractViewTestCase):
+class ToggleModeSwitchTestCase(AbstractViewTestCase):
     def test_user_authenticated_on(self):
-        url = reverse("preview_mode", kwargs={"preview_mode": 1})
+        url = reverse("toggle-preview-mode")
         url = url + "?next=/"
         self.login()
 
-        self.assertFalse(User.objects.get().preview_mode)
+        self.assertFalse(User.objects.first().preview_mode)
 
         result = self.client.get(url)
 
-        self.assertEqual(
-            result.url, "/"
-        )
-        self.assertTrue(User.objects.get().preview_mode)
+        self.assertEqual(result.url, "/")
+        self.assertTrue(User.objects.first().preview_mode)
 
     def test_user_authenticated_off(self):
-        url = reverse("preview_mode", kwargs={"preview_mode": 0})
+        url = reverse("toggle-preview-mode")
         url = url + "?next=/"
         self.login()
-        self.assertFalse(self.user.preview_mode)
+        self.assertFalse(User.objects.first().preview_mode)
 
-        self.user.preview_mode = True
-        self.user.save()
+        self.user.toggle_preview_mode()
 
         result = self.client.get(url)
-        self.assertEqual(
-            result.url, "/"
-        )
-        self.assertFalse(User.objects.get().preview_mode)
+        self.assertEqual(result.url, "/")
+        self.assertFalse(User.objects.first().preview_mode)
 
     def test_user_not_authenticated(self):
-        url = reverse("preview_mode", kwargs={"preview_mode": 1})
+        url = reverse("toggle-preview-mode")
         result = self.client.get(url)
-        self.assertEqual(
-            result.url, '/accounts/login/?next=/form/preview_mode/1'
-        )
+        self.assertEqual(result.url, '/accounts/login/?next=/toggle-preview-mode')
 
 
 class PublishAllTestCase(AbstractViewTestCase):

--- a/csv_schema/urls.py
+++ b/csv_schema/urls.py
@@ -2,17 +2,17 @@ from django.urls import include, path
 from django.views.generic import TemplateView
 
 from . import api
-from .views import ColumnDetail, FormRedirect, IndexView, PreviewModeSwitch, PublishAll
+from .views import ColumnDetail, FormRedirect, IndexView, PublishAll, TogglePreviewMode
 from .views.data_element import DataElementDetail, DataElementList
 from .views.database import DatabaseDetail, DatabaseList
 from .views.grouping import GroupingDetail, GroupingList
 from .views.table import TableAPI, TableDetail
 
 urlpatterns = [
+    path("toggle-preview-mode", TogglePreviewMode.as_view(), name="toggle-preview-mode"),
 
     # form urls
     path('form/', FormRedirect.as_view(), name="redirect"),
-    path('form/preview_mode/<int:preview_mode>', PreviewModeSwitch.as_view(), name="preview_mode"),
     path('form/publish_all/', PublishAll.as_view(), name="publish_all"),
 
     path('about/', TemplateView.as_view(template_name="about.html"), name="about_page"),

--- a/csv_schema/views/__init__.py
+++ b/csv_schema/views/__init__.py
@@ -2,6 +2,7 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
+from django.urls import reverse
 from django.views.generic import DetailView, RedirectView, View
 
 from ..models import Column, Database
@@ -37,14 +38,12 @@ class PublishAll(LoginRequiredMixin, View):
         return redirect(request.GET["next"])
 
 
-class PreviewModeSwitch(LoginRequiredMixin, RedirectView):
-    """ Switch the preview mode on or off for a user
-        gets passed in an integer that we boolerise™
-    """
-    def get_redirect_url(self, *args, **kwargs):
-        return self.request.GET["next"]
+class TogglePreviewMode(LoginRequiredMixin, RedirectView):
+    """Toggle preview_mode on the current user."""
 
     def get(self, request, *args, **kwargs):
-        self.request.user.preview_mode = bool(self.kwargs["preview_mode"])
-        self.request.user.save()
+        request.user.toggle_preview_mode()
         return super().get(request, *args, **kwargs)
+
+    def get_redirect_url(self):
+        return self.request.GET.get("next", reverse("index_view"))

--- a/ncdr/models.py
+++ b/ncdr/models.py
@@ -202,3 +202,8 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def has_module_perms(self, module):
         return _user_has_module_perms(self, module)
+
+    def toggle_preview_mode(self):
+        """Toggle the preview_mode boolean"""
+        self.preview_mode = not self.preview_mode
+        self.save()

--- a/ncdr/models.py
+++ b/ncdr/models.py
@@ -189,14 +189,6 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     objects = UserManager()
 
-    @classmethod
-    def get_url_preview_mode_off(cls):
-        return reverse("preview_mode", kwargs={"preview_mode": 0})
-
-    @classmethod
-    def get_url_preview_mode_on(cls):
-        return reverse("preview_mode", kwargs={"preview_mode": 1})
-
     def has_perm(self, perm, obj=None):
         return _user_has_perm(self, perm, obj=obj)
 


### PR DESCRIPTION
This changes the generation of switching Preview Mode's URL to a static URL and instead relies on our ability to flip a boolean (rather than consuming magic numbers) to handle the actual toggle action itself.

Fixes #48 