### PR TITLE
Paginator fixes: the << was not working as it didn't get passed the request dictionary…

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ line_length=88
 multi_line_output=3
 skip_glob = .direnv,**/migrations/**
 use_parentheses=True
-known_third_party = boto3,django,environ,more_itertools,pytest,redis,rq,structlog
+known_third_party = boto3,django,environ,mock,more_itertools,pytest,redis,rq,structlog

--- a/ncdr/templates/data_element_detail.html
+++ b/ncdr/templates/data_element_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block contents %}
 <div class="container main-content">
@@ -56,31 +57,6 @@
     </div>
   </div>
 
-  <div class="row">
-    <div class="col-md-12">
-      {% if is_paginated %}
-      <ul class="pagination">
-        {% if page_obj.has_previous %}
-        <li><a href="?page={{ page_obj.previous_page_number }}">&laquo;</a></li>
-        {% else %}
-        <li class="disabled"><span>&laquo;</span></li>
-        {% endif %}
-        {% for i in paginator.page_range %}
-        {% if page_obj.number == i %}
-        <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-        {% else %}
-        <li><a href="?page={{ i }}">{{ i }}</a></li>
-        {% endif %}
-        {% endfor %}
-        {% if page_obj.has_next %}
-        <li><a href="?page={{ page_obj.next_page_number }}">&raquo;</a></li>
-        {% else %}
-        <li class="disabled"><span>&raquo;</span></li>
-        {% endif %}
-      </ul>
-      {% endif %}
-    </div>
-  </div>
-
+  {% pagination %}
 </div>
 {% endblock %}

--- a/ncdr/templates/data_element_list.html
+++ b/ncdr/templates/data_element_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block contents %}
   <div class="card-list container main-content">
@@ -45,27 +46,7 @@
           {% endfor %}
         </div>
       </div>
-      {% if is_paginated %}
-        <ul class="pagination">
-          {% if page_obj.has_previous %}
-            <li><a href="?page={{ page_obj.previous_page_number }}&letter={{ request.GET.letter }}">&laquo;</a></li>
-          {% else %}
-            <li class="disabled"><span>&laquo;</span></li>
-          {% endif %}
-          {% for i in paginator.page_range %}
-            {% if page_obj.number == i %}
-              <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-            {% else %}
-              <li><a href="?page={{ i }}&letter={{ request.GET.letter }}">{{ i }}</a></li>
-            {% endif %}
-          {% endfor %}
-          {% if page_obj.has_next %}
-          <li><a href="?page={{ page_obj.next_page_number }}&letter={{ request.GET.letter }}">&raquo;</a></li>
-          {% else %}
-            <li class="disabled"><span>&raquo;</span></li>
-          {% endif %}
-        </ul>
-      {% endif %}
+      {% pagination %}
     </article>
   </div>
 {% endblock contents %}

--- a/ncdr/templates/search.html
+++ b/ncdr/templates/search.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block contents %}
 <div class="container main-content">
@@ -39,30 +40,7 @@
 
     {% endfor %}
 
-    {% if is_paginated %}
-      <ul class="pagination">
-        {% if page_obj.has_previous %}
-          <li><a href="?page={{ page_obj.previous_page_number }}&{{ query }}">&laquo;</a></li>
-        {% else %}
-          <li class="disabled"><span>&laquo;</span></li>
-        {% endif %}
-        {% for i in paginator.page_range %}
-          {% if i > page_obj.number|add:-5 and i < page_obj.number|add:5 %}
-            {% if page_obj.number == i %}
-              <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-            {% else %}
-              <li><a href="?page={{ i }}&{{ query }}">{{ i }}</a></li>
-            {% endif %}
-          {% endif %}
-        {% endfor %}
-        {% if page_obj.has_next %}
-          <li><a href="?page={{ page_obj.next_page_number }}&{{ query }}">&raquo;</a></li>
-        {% else %}
-          <li class="disabled"><span>&raquo;</span></li>
-        {% endif %}
-      </ul>
-    {% endif %}
-
+    {% pagination %}
   </div>
 </div>
 

--- a/ncdr/templates/search.html
+++ b/ncdr/templates/search.html
@@ -42,15 +42,17 @@
     {% if is_paginated %}
       <ul class="pagination">
         {% if page_obj.has_previous %}
-          <li><a href="?page={{ page_obj.previous_page_number }}">&laquo;</a></li>
+          <li><a href="?page={{ page_obj.previous_page_number }}&q={{ request.GET.q }}">&laquo;</a></li>
         {% else %}
           <li class="disabled"><span>&laquo;</span></li>
         {% endif %}
         {% for i in paginator.page_range %}
-          {% if page_obj.number == i %}
-            <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-          {% else %}
-            <li><a href="?page={{ i }}&q={{ request.GET.q }}">{{ i }}</a></li>
+          {% if i > page_obj.number|add:-5 and i < page_obj.number|add:5 %}
+            {% if page_obj.number == i %}
+              <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+            {% else %}
+              <li><a href="?page={{ i }}&q={{ request.GET.q }}">{{ i }}</a></li>
+            {% endif %}
           {% endif %}
         {% endfor %}
         {% if page_obj.has_next %}

--- a/ncdr/templates/search.html
+++ b/ncdr/templates/search.html
@@ -11,7 +11,7 @@
       <li>
         <a
           class="table-link{% if result.name == model_name %} active{% endif %}"
-          href="{% url 'search' model_name=result.name %}?q={{ request.GET.q }}">
+          href="{% url 'search' model_name=result.name %}?{{ query }}">
           {{ result.display_name }}
           <span class="pull-right">{{ result.count }}</span>
         </a>
@@ -42,7 +42,7 @@
     {% if is_paginated %}
       <ul class="pagination">
         {% if page_obj.has_previous %}
-          <li><a href="?page={{ page_obj.previous_page_number }}&q={{ request.GET.q }}">&laquo;</a></li>
+          <li><a href="?page={{ page_obj.previous_page_number }}&{{ query }}">&laquo;</a></li>
         {% else %}
           <li class="disabled"><span>&laquo;</span></li>
         {% endif %}
@@ -51,12 +51,12 @@
             {% if page_obj.number == i %}
               <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
             {% else %}
-              <li><a href="?page={{ i }}&q={{ request.GET.q }}">{{ i }}</a></li>
+              <li><a href="?page={{ i }}&{{ query }}">{{ i }}</a></li>
             {% endif %}
           {% endif %}
         {% endfor %}
         {% if page_obj.has_next %}
-          <li><a href="?page={{ page_obj.next_page_number }}&q={{ request.GET.q }}">&raquo;</a></li>
+          <li><a href="?page={{ page_obj.next_page_number }}&{{ query }}">&raquo;</a></li>
         {% else %}
           <li class="disabled"><span>&raquo;</span></li>
         {% endif %}

--- a/ncdr/templates/template_tags/pagination.html
+++ b/ncdr/templates/template_tags/pagination.html
@@ -1,0 +1,27 @@
+<div class="row">
+  <div class="col-md-12">
+    {% if is_paginated %}
+    <ul class="pagination">
+      {% if page_obj.has_previous %}
+        <li><a href="?page={{ page_obj.previous_page_number }}{{ paginator_query_string }}">&laquo;</a></li>
+      {% else %}
+        <li class="disabled"><span>&laquo;</span></li>
+      {% endif %}
+      {% for i in paginator.page_range %}
+        {% if i > page_obj.number|add:-5 and i < page_obj.number|add:5 %}
+          {% if page_obj.number == i %}
+            <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+          {% else %}
+            <li><a href="?page={{ i }}{{ paginator_query_string }}">{{ i }}</a></li>
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      {% if page_obj.has_next %}
+        <li><a href="?page={{ page_obj.next_page_number }}{{ paginator_query_string }}">&raquo;</a></li>
+      {% else %}
+        <li class="disabled"><span>&raquo;</span></li>
+      {% endif %}
+    </ul>
+    {% endif %}
+  </div>
+</div>

--- a/ncdr/templatetags/utils.py
+++ b/ncdr/templatetags/utils.py
@@ -13,3 +13,24 @@ def chunked(iterable, chunk_size):
 @register.filter(name="url_name")
 def url_name(request):
     return resolve(request.path_info).url_name
+
+
+@register.inclusion_tag("template_tags/pagination.html", takes_context=True)
+def pagination(context):
+    """
+    Assumes we are in a list view with a paginator.
+
+    Adds a variable to the context which is the string
+    used by the paginator without the page attribute
+    so that we can set that ourselves.
+    """
+    query_dict = context["request"].GET.copy()
+    if "page" in query_dict:
+        query_dict.pop("page")
+    encoded_query = query_dict.urlencode()
+    if encoded_query:
+        query = f"&{encoded_query}"
+    else:
+        query = ""
+    context["paginator_query_string"] = query
+    return context

--- a/ncdr/views/search.py
+++ b/ncdr/views/search.py
@@ -4,6 +4,7 @@ import operator
 from django.db.models import Q
 from django.http import Http404
 from django.urls import reverse
+from django.utils.http import urlencode
 from django.views.generic import ListView, RedirectView
 
 from ..models import Column, Database, DataElement, Grouping, Table
@@ -86,7 +87,7 @@ class Search(ListView):
         context["model_name"] = model_name
         context["model_display_name"] = info["model"]._meta.verbose_name
         context["model_template"] = f"search/{model_name}.html"
-
+        context["query"] = urlencode({"q": q})
         return self.render_to_response(context)
 
 

--- a/tests/ncdr/test_template_tags.py
+++ b/tests/ncdr/test_template_tags.py
@@ -1,0 +1,31 @@
+import mock
+from django.http.request import QueryDict
+
+from ncdr.templatetags.utils import pagination
+
+
+def test_pagination_with_page():
+    qd = QueryDict("page=2&letter=A")
+    request = mock.MagicMock()
+    request.GET = qd
+    ctx = {"request": request}
+    result = pagination(ctx)
+    assert result["paginator_query_string"] == "&letter=A"
+
+
+def test_pagination_without_page():
+    qd = QueryDict("letter=A")
+    request = mock.MagicMock()
+    request.GET = qd
+    ctx = {"request": request}
+    result = pagination(ctx)
+    assert result["paginator_query_string"] == "&letter=A"
+
+
+def test_pagination_with_no_args():
+    qd = QueryDict()
+    request = mock.MagicMock()
+    request.GET = qd
+    ctx = {"request": request}
+    result = pagination(ctx)
+    assert result["paginator_query_string"] == ""


### PR DESCRIPTION
I'm afraid this PR fixes 3 bugs because they all overlap.

1. Pagination back arrows were not being passed the query dict.

2.Pagination was not being limited by the page number so the range was going on forever

3.Search was not being urlencoded

This url encodes the search. It adds a pagination template tag to make sure that the pagination always works and fixes the first 2 bugs.

